### PR TITLE
Update Docker documentation

### DIFF
--- a/docs/installation_docker.md
+++ b/docs/installation_docker.md
@@ -1,25 +1,28 @@
 # Docker
 
-_Note: VERY beta._  
-This page is most definitely a WIP.  
-
 ## Pre-Run Requirements
 
 fHDHR does not create a config file itself, nor does it come with a default one in place. If enough demand for one is there we may build a check to auto-create it, but at present there is no plan to do so.  
 As such, before you run either of the below methods (only one, not both), be sure to create the folder and config file that you'll be passing in to the fHDHR container.  
-In this example, we're assuming you're using `/opt/docker/fhdhr/config` as the folder for it. The below commands in SSH should get this done.  
+
+## Creating Required Paths
+The following commands will create the required directories and files. Be sure change the directory path to match your desired location.
 
 ```bash
-mkdir -p /opt/docker/fhdhr/config
-mkdir -p /opt/docker/fhdhr/plugins
-touch /opt/docker/fhdhr/config/config.ini
+mkdir -p /path/to/config
+mkdir -p /path/to/plugins
+touch /path/to/config/config.ini
 ```
+
+> If you wish to keep a persistent cache, you can also create a directory for the cache. This allows channels that were disabled or favorited to be persistent after restarting the container.
 
 ## Docker CLI
 
 ```bash
-docker run -d --name=fhdhr -v /opt/docker/fhdhr/config:/app/config -v /opt/docker/fhdhr/plugins:/app/plugins --network host --restart=unless-stopped fhdhr/fhdhr:latest
+docker run -d --name=fhdhr -v /path/to/config:/app/config -v /path/to/plugins:/app/plugins --network host --restart=unless-stopped fhdhr/fhdhr:latest
 ```
+
+> If you wish to include the persistent cache, simply include `-v /path/to/cache:/app/data/cache` in the above command.
 
 ## Docker Compose
 
@@ -34,8 +37,9 @@ services:
       - PGID=1000
       - TZ=Pacific/Auckland
     volumes:
-      - /opt/docker/fhdhr/config:/app/config
-      - /opt/docker/fhdhr/plugins:/app/plugins
+      - /path/to/config:/app/config
+      - /path/to/plugins:/app/plugins
+      - /path/to/cache:/app/data/cache # Optional
     network_mode: host
     restart: unless-stopped
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,50 +34,7 @@ _The script will not run without this - there is no default configuration file l
 
 ### Docker
 
-This portion of the guide assumes you are using a Linux system with both docker and docker-compose installed. This (or some variation thereof) may work on Mac or Windows, but has not been tested.
-
-> TThis guide assumes we wish to use the `~/fhdhr` directory for our install (you can use whatever directory you like, just make the appropriate changes elsewhere in this guide).  
-> Run the following commands to clone the repo into `~/fhdhr/fHDHR`
-
-```bash
-cd ~/fhdhr
-git clone https://github.com/fHDHR/fHDHR.git
-```
-
-* Create your config.ini file (as described earlier in this guide) in the `~/fhdhr/fHDHR` directory.
-* While still in the `~/fhdhr` directory, create the following `docker-compose.yml` file.
-
-```yml
-version: '3'
-
-services:
-  fhdhr:
-    build: ./fHDHR
-    container_name: fhdhr
-    network_mode: host
-    volumes:
-      - ./fHDHR/config.ini:/app/config/config.ini
-```
-
-* Run the following command to build and launch the container.
-
-```bash
-docker-compose up --build -d fhdhr
-```
-
-After a short period of time (during which docker will build your new fHDHR container), you should now have a working build of fHDHR running inside a docker container.
-
-As the code changes and new versions / bug fixes are released, at any point you can pull the latest version of the code and rebuild your container with the following commands:
-
-```bash
-cd ~/fhdhr/fHDHR
-git checkout master
-git pull
-cd ~/fhdhr
-docker-compose up --build -d fhdhr
-```
-
-You can repeat these instructions for as many fHDHR containers as your system resources will allow, changing the port it runs on.
+If you wish to use fHDHR in Docker, then check out the [Docker documentation](./installation_docker.md). 
 
 ## Setup
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,19 +18,45 @@
 
 ### Linux
 
-The below instructions use the user "sysop", but you can run it as any user. The script will allow you to run as root, but warns against doing so.
+> The below instructions use the user "sysop", but you can run it as any user. The script will allow you to run as root, but warns against doing so.
 
-* Download the release zip, or git clone to your prefered location.  
-`cd /home/sysop && git clone https://github.com/fHDHR/fHDHR.git`
-* Navigate into your script directory and install the python requirements.  
-`cd fHDHR && pip3 install -r requirements.txt`
-* Copy the included `config.example.ini` file to a known location.  
-_The script will not run without this - there is no default configuration file location._  
-[Modify the configuration file to suit your needs.](../config)  
-`cp config.example.ini /home/sysop/config.ini`  
-* [Install plugins.](../plugins) fHDHR will technically run without plugins installed, but is particularly useless without an "origin" plugin.  
-* Install plugin python requirements file with the `pip3 install -r requirements.txt` for each plugin.  
-* Run with the path to the config file. `python3 /home/sysop/fhdhr/main.py -c=/home/sysop/config.ini`
+1. Download the release zip, or git clone to your prefered location.  
+
+```bash
+cd /home/sysop && git clone https://github.com/fHDHR/fHDHR.git
+```
+
+2. Navigate into your script directory and install the python requirements.  
+
+```bash
+cd fHDHR && pip3 install -r requirements.txt
+```
+
+3. Copy the included `config.example.ini` file to a known location:
+
+```bash
+cp config.example.ini /home/sysop/config.ini
+```
+
+> The script will not run without this - there is no default configuration file location. 
+ 
+4. Modify the configuration file to suit your needs.
+
+5. Install desired fHDHR plugins.
+
+> fHDHR will technically run without plugins installed, but is practically useless without an "origin" plugin.  
+
+6. Install plugin python requirements file:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+7. Run with the path to the config file:
+
+```bash
+python3 /home/sysop/fhdhr/main.py -c=/home/sysop/config.ini
+```
 
 ### Docker
 
@@ -38,6 +64,8 @@ If you wish to use fHDHR in Docker, then check out the [Docker documentation](./
 
 ## Setup
 
-Now that you have fHDHR running, You can navigate (in a web browser) to the IP:Port from the configuration step above.  
+Now that you have fHDHR running, you can navigate (in a web browser) to the IP:Port from the configuration step above.  
+
 If you did not setup a `discovery_address` in your config, SSDP will be disabled. This is not a problem as clients like Plex can have the IP:Port entered manually!  
+
 You can copy the xmltv link from the webUI and use that in your client software to provide Channel Guide information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,5 @@ nav:
   - Plugins: plugins.md
   - WebUI: webui.md
   - Usage: usage.md
-  - Related Projects: related_projects.md
   - Getting Involved:
     - Submitting to the docs: submitting_docs.md


### PR DESCRIPTION
Updated Docker and Linux documentation, also removed broken nav link.

Changes tested and verified to function using local MkDocs.

> These changes are best to be included after [this PR](https://github.com/fHDHR/fHDHR/pull/316) has been merged since the Docker docs have been simplified to rely on this.